### PR TITLE
Include "getrandom" feature in rand_core to remove rand dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,4 @@ exclude = [
 [dependencies]
 ed448-goldilocks = "0.7.0"
 hex = "0.4.0"
-rand_core = { version = "0.5", default-features = false }
-
-[dev-dependencies]
-rand ="0.7" # XXX: Want to remove this, but rand_core won't compile in tests without it
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] } }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ exclude = [
 [dependencies]
 ed448-goldilocks = "0.7.0"
 hex = "0.4.0"
-rand_core = { version = "0.5", default-features = false, features = ["getrandom"] } }
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] } 


### PR DESCRIPTION
Inclusion of the "getrandom" feature exposes rand_core::OsRng, allowing compilation without the additional "rand = 0.7" dev dependency