### PR TITLE
add Zeroize support for SharedSecret and Secret

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed448-goldilocks = "0.7.0"
+ed448-goldilocks = { version = "0.8.3", features = ["zeroize"] }
 hex = "0.4.0"
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"] } 
+
+[dependencies.zeroize]
+version = "1"
+default-features = false
+features = ["zeroize_derive"]

--- a/src/x448.rs
+++ b/src/x448.rs
@@ -1,6 +1,7 @@
 use ed448_goldilocks::curve::MontgomeryPoint;
 use ed448_goldilocks::Scalar;
 use rand_core::{CryptoRng, RngCore};
+use zeroize::Zeroize;
 
 /// Computes a Scalar according to RFC7748
 /// given a byte array of length 56
@@ -30,6 +31,8 @@ pub struct Secret([u8; 56]);
 
 /// A SharedSecret is a point on Curve448.
 /// This point is the result of a Diffie-Hellman key exchange.
+#[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct SharedSecret(MontgomeryPoint);
 
 impl PublicKey {

--- a/src/x448.rs
+++ b/src/x448.rs
@@ -30,7 +30,7 @@ pub struct Secret([u8; 56]);
 
 /// A SharedSecret is a point on Curve448.
 /// This point is the result of a Diffie-Hellman key exchange.
-pub type SharedSecret = PublicKey;
+pub struct SharedSecret(MontgomeryPoint);
 
 impl PublicKey {
     /// Converts a bytes slice into a Public key
@@ -61,6 +61,13 @@ impl PublicKey {
     }
 
     /// Converts a public key into a byte slice
+    pub fn as_bytes(&self) -> &[u8; 56] {
+        self.0.as_bytes()
+    }
+}
+
+impl SharedSecret {
+    /// Converts a shared secret into a byte slice
     pub fn as_bytes(&self) -> &[u8; 56] {
         self.0.as_bytes()
     }
@@ -98,7 +105,7 @@ impl Secret {
             return None;
         }
         let shared_key = &public_key.0 * &self.as_scalar();
-        Some(PublicKey(shared_key))
+        Some(SharedSecret(shared_key))
     }
 
     /// Performs a Diffie-hellman key exchange once between the secret key and an external public key

--- a/src/x448.rs
+++ b/src/x448.rs
@@ -27,6 +27,8 @@ impl From<&Secret> for PublicKey {
 pub struct PublicKey(MontgomeryPoint);
 
 /// A Secret is a Scalar on Curve448.
+#[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct Secret([u8; 56]);
 
 /// A SharedSecret is a point on Curve448.


### PR DESCRIPTION
Note that I also made `SharedSecret` a new type instead of a type alias, for two reasons:

- It is a slightly safer API with minimal additional code
- It allows `SharedSecret` to be zeroized on drop without the overhead of doing the same for `PublicKey`

I also just noted that `Secret::as_scalar()` calls `Scalar::from_bytes()` and thus creates a copy. I *didn't add* zeroize support for `Scalar` (yet).